### PR TITLE
Add @hookform/resolvers to manual installation

### DIFF
--- a/apps/www/content/docs/components/form.mdx
+++ b/apps/www/content/docs/components/form.mdx
@@ -100,7 +100,7 @@ npx shadcn-ui@latest add form
 <Step>Install the following dependencies:</Step>
 
 ```bash
-npm install @radix-ui/react-label @radix-ui/react-slot react-hook-form
+npm install @radix-ui/react-label @radix-ui/react-slot react-hook-form @hookform/resolvers
 ```
 
 <Step>Copy and paste the following code into your project.</Step>


### PR DESCRIPTION
The `@hookform/resolvers` is missing from the manual installation 